### PR TITLE
[RFR] Splitting unit tests into distinct modules

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
-
 import pytest
 
 from click.testing import CliRunner

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+import pytest
+
+from click.testing import CliRunner
+
+from disruption_generator import cli
+
+
+@pytest.fixture(scope='module')
+def runner():
+    return CliRunner()
+
+
+def test_help_message(runner):
+    help_result = runner.invoke(cli.main, args=['--help'])
+    assert help_result.exit_code == 0
+    assert "Show this message and exit." in help_result.output

--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -1,23 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-"""Tests for `disruption_generator` package."""
-
 import asyncssh
 import pytest
 
-from click.testing import CliRunner
-
-from disruption_generator import cli
 from disruption_generator.listener.alistener import Alistener
-
-
-def test_command_line_interface():
-    """Test the CLI."""
-    runner = CliRunner()
-    help_result = runner.invoke(cli.main, ["--help"])
-    assert help_result.exit_code == 0
-    assert "Show this message and exit." in help_result.output
 
 
 @pytest.mark.asyncio

--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import asyncssh
 import pytest
 


### PR DESCRIPTION
I started this PR with the intent of expansion of unit test suite. However then I realized that #30 changes a lot of basic interfaces, so the unit tests would have to be reworked soon after merging it. Nonetheless, I think we can merge at least this now. There's really not anything new, I just split the unit tests to distinct modules. I don't think we really want to keep them in one module.