### PR TITLE
[RFR] New logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ Pipfile.lock
 development.cfg
 *.swp
 disruption_generator/tools/ovirt-inventory/inventory
+
+# User configuration
+disruption_generator/custom_logging.yaml

--- a/disruption_generator/cli.py
+++ b/disruption_generator/cli.py
@@ -5,13 +5,15 @@ import asyncio
 import asyncssh
 import sys
 import click
-import logging
+import logging.config
+import yaml
 
 from . import __version__
 from .parsers.experiment_parser import ExperimentParser
 from .listener.alistener import Alistener
 from .trigger.trigger import Trigger
 from os import walk, path
+
 
 logger = logging.getLogger(__name__)
 
@@ -20,9 +22,7 @@ logger = logging.getLogger(__name__)
 @click.option(
     "--experiments-path",
     "-e",
-    type=click.Path(
-        exists=True, file_okay=False, readable=True, resolve_path=True
-    ),
+    type=click.Path(exists=True, file_okay=False, readable=True, resolve_path=True),
     help="Path to experiments yamls",
     default="./experiments/",
 )
@@ -40,6 +40,7 @@ def main(experiments_path, ssh_host_key):
     """Console script for disruption_generator."""
     click.echo("!!! DISRUPTION AS A SERVICE !!!")
     click.echo("!!!    USE WITH CAUTION     !!!")
+    parse_log_config(default_config_file="default_logging.yaml", custom_config_file="custom_config.yaml")
     try:
         loop = asyncio.get_event_loop()
         loop.run_until_complete(execute(experiments_path, ssh_host_key))
@@ -56,6 +57,7 @@ async def execute(experiments_path, ssh_host_key):
             for _file in filenames
             if _file.endswith((".yaml", ".yml"))
         ]
+        logger.debug("Experiment files to be parsed: {}".format(_files))
         _ignored = [
             path.join(dirpath, _file)
             for _file in filenames
@@ -73,8 +75,9 @@ async def execute(experiments_path, ssh_host_key):
         _parser = ExperimentParser(yaml_path=_file)
         scenario = _parser.parse()
         _scenarios.extend(scenario)
+    logger.debug("Scenarios to play: {}".format(_scenarios))
     for scenario in _scenarios:
-        click.echo("Scenario: %s" % scenario.name)
+        logger.info("Scenario: {}".format(scenario.name))
         alistener = Alistener(
             scenario.listener.target,
             scenario.listener.username,
@@ -83,12 +86,10 @@ async def execute(experiments_path, ssh_host_key):
         )
 
         for action in scenario.actions:
-            result = await alistener.tail(
-                scenario.listener.log, scenario.listener.re, action.timeout
-            )
+            result = await alistener.tail(scenario.listener.log, scenario.listener.re, action.timeout)
 
             if result:
-                click.echo("Triggering: %s" % action.name)
+                logger.info("Triggering: {}".format(action.name))
                 _username = action.username if action.username else "root"
                 trigger = Trigger(
                     action, _username, action.password, ssh_host_key
@@ -101,6 +102,33 @@ async def execute(experiments_path, ssh_host_key):
                 await disruption()
 
     return 0
+
+
+def parse_log_config(default_config_file, custom_config_file):
+    """
+    This will look at logging configuration files and load the config using native abilities of
+    python logging.config module. In the first instance, default logging config provided by
+    Disruption Generator developers is loaded. After that custom configuration provided by user is
+    loaded and it overwrites the default configuration.
+    Args:
+        default_config_file (str): Path to file hodling default configuration
+        custom_config_file (str): Path to file hodling user configuration
+    Returns:
+        None
+    """
+    try:
+        with open(default_config_file, "r") as f:
+            default_config = yaml.safe_load(f)
+            logging.config.dictConfig(default_config)
+    except FileNotFoundError:
+        sys.exit("{} not found. Logging cannot be configured.".format(default_config_file))
+    try:
+        with open(custom_config_file, "r") as f:
+            custom_config = yaml.safe_load(f)
+            logging.config.dictConfig(custom_config)
+    except FileNotFoundError:
+        # If custom config file is not found, it's no probem. Default config will be used.
+        pass
 
 
 if __name__ == "__main__":

--- a/disruption_generator/cli.py
+++ b/disruption_generator/cli.py
@@ -29,9 +29,7 @@ logger = logging.getLogger(__name__)
 @click.option(
     "--ssh-host-key",
     "-k",
-    type=click.Path(
-        exists=True, file_okay=True, readable=True, resolve_path=True
-    ),
+    type=click.Path(exists=True, file_okay=True, readable=True, resolve_path=True),
     help="File with SSH private key to use a server host key",
     default=None,
 )
@@ -52,23 +50,11 @@ async def execute(experiments_path, ssh_host_key):
     ssh_host_key = ssh_host_key or [ssh_host_key]
     _files = []
     for (dirpath, dirnames, filenames) in walk(experiments_path):
-        _files = [
-            path.join(dirpath, _file)
-            for _file in filenames
-            if _file.endswith((".yaml", ".yml"))
-        ]
+        _files = [path.join(dirpath, _file) for _file in filenames if _file.endswith((".yaml", ".yml"))]
         logger.debug("Experiment files to be parsed: {}".format(_files))
-        _ignored = [
-            path.join(dirpath, _file)
-            for _file in filenames
-            if not _file.endswith((".yaml", ".yml"))
-        ]
+        _ignored = [path.join(dirpath, _file) for _file in filenames if not _file.endswith((".yaml", ".yml"))]
         if _ignored:
-            logger.debug(
-                "The following files where found but ignored: {}".format(
-                    _ignored
-                )
-            )
+            logger.debug("The following files where found but ignored: {}".format(_ignored))
         break  # Gets only root level directory files
     _scenarios = []
     for _file in _files:
@@ -79,10 +65,7 @@ async def execute(experiments_path, ssh_host_key):
     for scenario in _scenarios:
         logger.info("Scenario: {}".format(scenario.name))
         alistener = Alistener(
-            scenario.listener.target,
-            scenario.listener.username,
-            scenario.listener.password,
-            ssh_host_key,
+            scenario.listener.target, scenario.listener.username, scenario.listener.password, ssh_host_key
         )
 
         for action in scenario.actions:
@@ -91,9 +74,7 @@ async def execute(experiments_path, ssh_host_key):
             if result:
                 logger.info("Triggering: {}".format(action.name))
                 _username = action.username if action.username else "root"
-                trigger = Trigger(
-                    action, _username, action.password, ssh_host_key
-                )
+                trigger = Trigger(action, _username, action.password, ssh_host_key)
                 try:
                     disruption = getattr(trigger, action.name)
                 except AssertionError as err:

--- a/disruption_generator/custom_logging.example.yaml
+++ b/disruption_generator/custom_logging.example.yaml
@@ -1,0 +1,5 @@
+version: 1
+incremental: True
+loggers:
+  disruption_generator.cli:
+    level: WARN

--- a/disruption_generator/default_logging.yaml
+++ b/disruption_generator/default_logging.yaml
@@ -1,0 +1,41 @@
+# If you're not satisfied with the default values provided here,
+# you can create file called custom_logging.yaml in this directory.
+# In there, you can overwrite level setting for handlers and loggers.
+# Details: https://docs.python.org/3.7/library/logging.config.html#incremental-configuration
+# custom_logging.yaml must include incremental: True key-value pair.
+# See also custom_logging.example.yaml
+
+version: 1
+formatters:
+  simple:
+    datefmt: '%H:%M:%S'
+    format: '{asctime} [{levelname}] {message}'
+    style: '{'
+  detailed:
+    format: '{asctime} [{name}] [{levelname}] {message}'
+    style: '{'
+handlers:
+  console:
+    class: logging.StreamHandler
+    formatter: simple
+    level: DEBUG
+  main_log_file:
+    class: logging.FileHandler
+    filename: log/disruption_generator.log
+    formatter: detailed
+    level: DEBUG
+loggers:
+  disruption_generator.cli:
+    level: DEBUG
+    handlers: [console, main_log_file]
+  disruption_generator.listener.alistener:
+    level: DEBUG
+    handlers: [console, main_log_file]
+  disruption_generator.parsers.experiment_parser:
+    level: DEBUG
+    handlers: [console, main_log_file]
+  disruption_generator.trigger.trigger:
+    level: DEBUG
+    handlers: [console, main_log_file]
+incremental: False
+disable_existing_loggers: True


### PR DESCRIPTION
So, this is not really implementation of new logging. It's just laying down the idea how we might go about it. I went mainly for those effect:
* Scalabity: We can add as many loggers and let them to log as many handlers (read files) as we like to.
* Customization: Users can define their own desired logging level at each source (logger) and each destination (handler).
* Ease of maintenance: Logging config files are structured in a way that python `logging.config` library can process them out-of-the-box. That means we don't need to care about parsing it. 

What do y'all think about it? 